### PR TITLE
Add requirements.txt for PluMA automatic venv integration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+pycausal
+pydot


### PR DESCRIPTION
## Summary

Add `requirements.txt` declaring this plugin's Python dependencies so that
PluMA's new automatic virtual-environment system can install them during
build.

See the upstream PluMA change: https://github.com/FIUBioRG/PluMA/pull/11

With this PR merged, running `scons` in the PluMA root will automatically:
1. Scan every plugin's `requirements.txt`
2. Detect version conflicts across plugins
3. Install the merged dependencies into a shared `.venv/`
4. Activate the venv at runtime so plugins can import their dependencies
   without manual `pip install` or `source .venv/bin/activate`
